### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/ntree/Cargo.toml
+++ b/ntree/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MIT"
 description = "A mutable n-tree with async support"
 readme = "../README.md"
+repository = "https://github.com/HectorMRC/ntree-rs"
 
 [dependencies]
 async-recursion = { version = "1.0.4", optional = true }


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it.