### PR TITLE
feat: with pre and post

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
 A mutable n-ary tree with async support.
 
 ## About
-This library provides a simple way to define, mutate and traverse trees of an arbitrary and non-constant arity. In addition, regarding to traversal algorithms, four different implementations are included: the mutable and immutable approaches, as well as the synchronous and asynchronous strategies for both of them.
+This library provides a simple way to define, mutate and traverse trees of an arbitrary and non-constant arity. In addition, regarding to traversal algorithms, six different implementations are included: the immutable, mutable and owned approaches, as well as the synchronous and asynchronous strategies for each of them.

--- a/ntree-macros/Cargo.toml
+++ b/ntree-macros/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "ntree-macros"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 description = "Complementary proc macros for ntree-rs"
+repository = "https://github.com/HectorMRC/ntree-rs"
 
 [lib]
 path = "src/lib.rs"

--- a/ntree/Cargo.toml
+++ b/ntree/Cargo.toml
@@ -8,7 +8,7 @@ readme = "../README.md"
 repository = "https://github.com/HectorMRC/ntree-rs"
 
 [dependencies]
-async-recursion = { version = "1.0.4", optional = true }
+async-recursion = { version = "1.0.5", optional = true }
 futures = { version = "0.3.28", optional = true }
 
 [dev-dependencies]

--- a/ntree/Cargo.toml
+++ b/ntree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntree-rs"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 description = "A mutable n-tree with async support"

--- a/ntree/src/traversal/macros.rs
+++ b/ntree/src/traversal/macros.rs
@@ -25,7 +25,7 @@ macro_rules! for_each {
 macro_rules! map {
     ($node:ty, $iter:tt) => {
         /// Traverses the tree rooted by self in `pre-order`, building a new tree by calling the given closure along the way.
-        pub fn map<F, R>(self, mut f: F) -> TraverseOwned<R, Synchronous>
+        pub fn map<F, R>(self, mut f: F) -> $crate::TraverseOwned<R, Synchronous>
         where
             F: FnMut($node) -> R,
         {
@@ -33,7 +33,7 @@ macro_rules! map {
             where
                 F: FnMut($node) -> R,
             {
-                Node::new(f(root)).with_children(
+                $crate::Node::new(f(root)).with_children(
                     root.children
                         .$iter()
                         .map(|child| map_immersion::<T, F, R>(child, f))
@@ -41,7 +41,7 @@ macro_rules! map {
                 )
             }
 
-            TraverseOwned::new(map_immersion::<T, F, R>(self.node, &mut f))
+            $crate::TraverseOwned::new(map_immersion::<T, F, R>(self.node, &mut f))
         }
     };
 }
@@ -99,11 +99,11 @@ macro_rules! cascade {
 macro_rules! map_pre {
     ($node:ty, $iter:tt) => {
         /// Traverses the tree in `pre-order`, building a new tree by calling the given closure along the way.
-        pub fn map<R, F>(self, base: R, mut pre: F) -> Node<R>
+        pub fn map<R, F>(self, base: R, mut pre: F) -> $crate::Node<R>
         where
             F: FnMut($node, &R) -> R,
         {
-            fn map_immersion<T, R, F>(root: $node, base: &R, f: &mut F) -> Node<R>
+            fn map_immersion<T, R, F>(root: $node, base: &R, f: &mut F) -> $crate::Node<R>
             where
                 F: FnMut($node, &R) -> R,
             {
@@ -125,21 +125,21 @@ macro_rules! map_pre {
 macro_rules! map_post {
     ($node:ty, $iter:tt) => {
         /// Traverses the tree in `post-order`, building a new tree by calling the given closure along the way.
-        pub fn map<F, R>(self, mut post: F) -> Node<R>
+        pub fn map<F, R>(self, mut post: F) -> $crate::Node<R>
         where
-            F: FnMut($node, &[Node<R>]) -> R,
+            F: FnMut($node, &[$crate::Node<R>]) -> R,
         {
-            fn map_immersion<T, R, F>(root: $node, f: &mut F) -> Node<R>
+            fn map_immersion<T, R, F>(root: $node, f: &mut F) -> $crate::Node<R>
             where
-                F: FnMut($node, &[Node<R>]) -> R,
+                F: FnMut($node, &[$crate::Node<R>]) -> R,
             {
-                let children: Vec<Node<R>> = root
+                let children: Vec<$crate::Node<R>> = root
                     .children
                     .$iter()
                     .map(|node| map_immersion(node, f))
                     .collect();
 
-                Node::new(f(root, &children)).with_children(children)
+                $crate::Node::new(f(root, &children)).with_children(children)
             }
 
             map_immersion(self.node, &mut post)
@@ -185,29 +185,29 @@ macro_rules! map_pre_post {
     ($node:ty, $iter:tt) => {
         /// Traverses the tree in both orders, building a new tree by calling the post closure along the way.
         /// Returns the latest result given by the post closure, which value correspond to the root of the tree.
-        pub fn map<U, P>(mut self, base: R, mut post: P) -> Node<U>
+        pub fn map<U, P>(mut self, base: R, mut post: P) -> $crate::Node<U>
         where
             F: FnMut($node, &R) -> R,
-            P: FnMut($node, R, &[Node<U>]) -> U,
+            P: FnMut($node, R, &[$crate::Node<U>]) -> U,
         {
             fn map_immersion<T, R, U, F1, F2>(
                 root: $node,
                 base: &R,
                 pre: &mut F1,
                 post: &mut F2,
-            ) -> Node<U>
+            ) -> $crate::Node<U>
             where
                 F1: FnMut($node, &R) -> R,
-                F2: FnMut($node, R, &[Node<U>]) -> U,
+                F2: FnMut($node, R, &[$crate::Node<U>]) -> U,
             {
                 let base = pre(root, base);
-                let children: Vec<Node<U>> = root
+                let children: Vec<$crate::Node<U>> = root
                     .children
                     .$iter()
                     .map(|node| map_immersion(node, &base, pre, post))
                     .collect();
 
-                Node::new(post(root, base, &children)).with_children(children)
+                $crate::Node::new(post(root, base, &children)).with_children(children)
             }
 
             map_immersion(self.node, &base, &mut self.pre, &mut post)

--- a/ntree/src/traversal/macros.rs
+++ b/ntree/src/traversal/macros.rs
@@ -63,6 +63,7 @@ macro_rules! reduce {
                     .$iter()
                     .map(|child| reduce_immersion(child, f))
                     .collect();
+
                 f(root, results)
             }
 

--- a/ntree/src/traversal/macros.rs
+++ b/ntree/src/traversal/macros.rs
@@ -96,7 +96,130 @@ macro_rules! cascade {
     };
 }
 
+macro_rules! map_pre {
+    ($node:ty, $iter:tt) => {
+        /// Traverses the tree in `pre-order`, building a new tree by calling the given closure along the way.
+        pub fn map<R, F>(self, base: R, mut pre: F) -> Node<R>
+        where
+            F: FnMut($node, &R) -> R,
+        {
+            fn map_immersion<T, R, F>(root: $node, base: &R, f: &mut F) -> Node<R>
+            where
+                F: FnMut($node, &R) -> R,
+            {
+                let parent = Node::new(f(root, base));
+                let children: Vec<Node<R>> = root
+                    .children
+                    .$iter()
+                    .map(|node| map_immersion(node, &parent.value, f))
+                    .collect();
+
+                parent.with_children(children)
+            }
+
+            map_immersion(self.node, &base, &mut pre)
+        }
+    };
+}
+
+macro_rules! map_post {
+    ($node:ty, $iter:tt) => {
+        /// Traverses the tree in `post-order`, building a new tree by calling the given closure along the way.
+        pub fn map<F, R>(self, mut post: F) -> Node<R>
+        where
+            F: FnMut($node, &[Node<R>]) -> R,
+        {
+            fn map_immersion<T, R, F>(root: $node, f: &mut F) -> Node<R>
+            where
+                F: FnMut($node, &[Node<R>]) -> R,
+            {
+                let children: Vec<Node<R>> = root
+                    .children
+                    .$iter()
+                    .map(|node| map_immersion(node, f))
+                    .collect();
+
+                Node::new(f(root, &children)).with_children(children)
+            }
+
+            map_immersion(self.node, &mut post)
+        }
+    };
+}
+
+macro_rules! reduce_pre_post {
+    ($node:ty, $iter:tt) => {
+        /// Traverses the tree calling both associated closures when corresponding.
+        /// Returns the latest result given by the post closure, which value correspond to the root of the tree.
+        pub fn reduce<U, P>(mut self, base: R, mut post: P) -> U
+        where
+            F: FnMut($node, &R) -> R,
+            P: FnMut($node, R, &[U]) -> U,
+        {
+            fn reduce_immersion<T, R, U, F1, F2>(
+                root: $node,
+                base: &R,
+                pre: &mut F1,
+                post: &mut F2,
+            ) -> U
+            where
+                F1: FnMut($node, &R) -> R,
+                F2: FnMut($node, R, &[U]) -> U,
+            {
+                let base = pre(root, base);
+                let children: Vec<U> = root
+                    .children
+                    .$iter()
+                    .map(|node| reduce_immersion(node, &base, pre, post))
+                    .collect();
+
+                post(root, base, &children)
+            }
+
+            reduce_immersion(self.node, &base, &mut self.pre, &mut post)
+        }
+    };
+}
+
+macro_rules! map_pre_post {
+    ($node:ty, $iter:tt) => {
+        /// Traverses the tree in both orders, building a new tree by calling the post closure along the way.
+        /// Returns the latest result given by the post closure, which value correspond to the root of the tree.
+        pub fn map<U, P>(mut self, base: R, mut post: P) -> Node<U>
+        where
+            F: FnMut($node, &R) -> R,
+            P: FnMut($node, R, &[Node<U>]) -> U,
+        {
+            fn map_immersion<T, R, U, F1, F2>(
+                root: $node,
+                base: &R,
+                pre: &mut F1,
+                post: &mut F2,
+            ) -> Node<U>
+            where
+                F1: FnMut($node, &R) -> R,
+                F2: FnMut($node, R, &[Node<U>]) -> U,
+            {
+                let base = pre(root, base);
+                let children: Vec<Node<U>> = root
+                    .children
+                    .$iter()
+                    .map(|node| map_immersion(node, &base, pre, post))
+                    .collect();
+
+                Node::new(post(root, base, &children)).with_children(children)
+            }
+
+            map_immersion(self.node, &base, &mut self.pre, &mut post)
+        }
+    };
+}
+
 pub(crate) use cascade;
 pub(crate) use for_each;
 pub(crate) use map;
+pub(crate) use map_post;
+pub(crate) use map_pre;
+pub(crate) use map_pre_post;
 pub(crate) use reduce;
+pub(crate) use reduce_pre_post;

--- a/ntree/src/traversal/macros_async.rs
+++ b/ntree/src/traversal/macros_async.rs
@@ -28,12 +28,12 @@ macro_rules! for_each {
 macro_rules! map {
     ($node:ty, $iter:tt) => {
         #[async_recursion]
-        async fn map_immersion<F, R>(root: $node, f: &F) -> Node<R>
+        async fn map_immersion<F, R>(root: $node, f: &F) -> $crate::Node<R>
         where
             F: Fn($node) -> R + Sync + Send,
             R: Sized + Sync + Send,
         {
-            Node::new(f(root)).with_children(
+            $crate::Node::new(f(root)).with_children(
                 join_all(
                     root.children
                         .$iter()
@@ -45,12 +45,12 @@ macro_rules! map {
 
         /// Builds a new tree by calling the given closure along the tree rooted by self following the
         /// pre-order traversal.
-        pub async fn map<F, R>(self, f: F) -> TraverseOwned<R, Asynchronous>
+        pub async fn map<F, R>(self, f: F) -> $crate::TraverseOwned<R, Asynchronous>
         where
             F: Fn($node) -> R + Sync + Send,
             R: Sized + Sync + Send,
         {
-            TraverseOwned::new_async(Self::map_immersion(self.node, &f).await)
+            $crate::TraverseOwned::new_async(Self::map_immersion(self.node, &f).await)
         }
     };
 }
@@ -103,7 +103,7 @@ macro_rules! cascade {
 
         /// Calls the given closure along the tree rooted by self, providing the parent's
         /// data to its children.
-        pub async fn cascade<F, R>(&self, base: R, f: F)
+        pub async fn cascade<F, R>(self, base: R, f: F)
         where
             F: Fn($node, &R) -> R + Sync + Send,
             R: Sized + Sync + Send,

--- a/ntree/src/traversal/mod.rs
+++ b/ntree/src/traversal/mod.rs
@@ -10,8 +10,8 @@ mod traverse_owned;
 pub use traverse_owned::*;
 
 mod macros;
-// #[cfg(feature = "async")]
-// mod macros_async;
+#[cfg(feature = "async")]
+mod macros_async;
 
 impl<'a, T> Node<T> {
     /// Returns a synchronous instance of [Traverse] for the given reference of node.

--- a/ntree/src/traversal/traverse/async.rs
+++ b/ntree/src/traversal/traverse/async.rs
@@ -1,6 +1,9 @@
 //! Asynchronous traversal implementation.
 
-use crate::{traversal::Traverse, Asynchronous, Node, Synchronous, TraverseOwned};
+use crate::{
+    traversal::{macros_async, Traverse},
+    Asynchronous, Node, Synchronous,
+};
 use async_recursion::async_recursion;
 use futures::future::join_all;
 use std::marker::PhantomData;
@@ -29,103 +32,10 @@ impl<'a, T: Sync + Send + 'a> Traverse<'a, T, Asynchronous> {
         }
     }
 
-    #[async_recursion]
-    async fn for_each_immersion<F>(root: &Node<T>, f: &F)
-    where
-        F: Fn(&Node<T>) + Sync + Send,
-    {
-        let futures: Vec<_> = root
-            .children
-            .iter()
-            .map(|child| Self::for_each_immersion(child, f))
-            .collect();
-
-        join_all(futures).await;
-        f(root);
-    }
-
-    /// Traverses the tree rooted by self in `post-order`, calling the given closure along the way.
-    pub async fn for_each<F>(self, f: F) -> Traverse<'a, T, Asynchronous>
-    where
-        F: Fn(&Node<T>) + Sync + Send,
-    {
-        Self::for_each_immersion(self.node, &f).await;
-        self
-    }
-
-    #[async_recursion]
-    async fn map_immersion<F, R>(root: &Node<T>, f: &F) -> Node<R>
-    where
-        F: Fn(&Node<T>) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        Node::new(f(root)).with_children(
-            join_all(
-                root.children
-                    .iter()
-                    .map(|child| Self::map_immersion(child, f)),
-            )
-            .await,
-        )
-    }
-
-    /// Traverses the tree rooted by self in `pre-order`, building a new tree by calling the given closure along the way.
-    pub async fn map<F, R>(self, f: F) -> TraverseOwned<R, Asynchronous>
-    where
-        F: Fn(&Node<T>) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        TraverseOwned::new_async(Self::map_immersion(self.node, &f).await)
-    }
-
-    #[async_recursion]
-    async fn reduce_immersion<F, R>(root: &Node<T>, f: &F) -> R
-    where
-        F: Fn(&Node<T>, Vec<R>) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        let results = join_all(
-            root.children
-                .iter()
-                .map(|child| Self::reduce_immersion(child, f)),
-        )
-        .await;
-        f(root, results)
-    }
-
-    /// Traverses the tree rooted by self in `post-order`, calling the given closure along the way and providing its results from children to parent.
-    pub async fn reduce<F, R>(self, f: F) -> R
-    where
-        F: Fn(&Node<T>, Vec<R>) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        Self::reduce_immersion(self.node, &f).await
-    }
-
-    #[async_recursion]
-    async fn cascade_immersion<F, R>(root: &Node<T>, base: &R, f: &F)
-    where
-        F: Fn(&Node<T>, &R) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        let base = f(root, base);
-        join_all(
-            root.children
-                .iter()
-                .map(|child| Self::cascade_immersion(child, &base, f)),
-        )
-        .await;
-    }
-
-    /// Traverses the tree rooted by self in `pre-order`, calling the given closure along the way and providing its result from parent to children.
-    pub async fn cascade<F, R>(self, base: R, f: F) -> Traverse<'a, T, Asynchronous>
-    where
-        F: Fn(&Node<T>, &R) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        Self::cascade_immersion(self.node, &base, &f).await;
-        self
-    }
+    macros_async::for_each!(&Node<T>, iter);
+    macros_async::map!(&Node<T>, iter);
+    macros_async::reduce!(&Node<T>, iter);
+    macros_async::cascade!(&Node<T>, iter);
 }
 
 #[cfg(test)]

--- a/ntree/src/traversal/traverse/mod.rs
+++ b/ntree/src/traversal/traverse/mod.rs
@@ -30,4 +30,104 @@ impl<'a, T, S> Traverse<'a, T, S> {
     pub fn node(&self) -> &Node<T> {
         self.node
     }
+
+    /// Returns the pre-order traversal entity for the tree.
+    pub fn pre<R, F>(self, pre: F) -> WithPre<'a, T, R, F, S>
+    where
+        F: FnMut(&Node<T>, &R) -> R,
+    {
+        WithPre {
+            node: self.node,
+            pre,
+            r: PhantomData,
+            strategy: PhantomData,
+        }
+    }
+
+    /// Returns the post-order traversal entity for the tree.
+    pub fn post<R, F>(self, post: F) -> WithPost<'a, T, R, F, S>
+    where
+        F: FnMut(&Node<T>, &[R]) -> R,
+    {
+        WithPost {
+            node: self.node,
+            post,
+            r: PhantomData,
+            strategy: PhantomData,
+        }
+    }
+}
+
+/// Represents the pre-order traversal.
+pub struct WithPre<'a, T, R, F, S>
+where
+    F: FnMut(&Node<T>, &R) -> R,
+{
+    node: &'a Node<T>,
+    pre: F,
+    r: PhantomData<R>,
+    strategy: PhantomData<S>,
+}
+
+impl<'a, T, R, F, S> WithPre<'a, T, R, F, S>
+where
+    F: FnMut(&Node<T>, &R) -> R,
+{
+    pub fn post<U, P>(self, post: P) -> WithPrePost<'a, T, R, U, F, P, S>
+    where
+        P: FnMut(&Node<T>, &[U]) -> U,
+    {
+        WithPrePost {
+            node: self.node,
+            pre: self.pre,
+            post,
+            r: PhantomData,
+            u: PhantomData,
+            strategy: PhantomData,
+        }
+    }
+}
+
+/// Represents the post-order traversal.
+pub struct WithPost<'a, T, R, F, S>
+where
+    F: FnMut(&Node<T>, &[R]) -> R,
+{
+    node: &'a Node<T>,
+    post: F,
+    r: PhantomData<R>,
+    strategy: PhantomData<S>,
+}
+
+impl<'a, T, R, F, S> WithPost<'a, T, R, F, S>
+where
+    F: FnMut(&Node<T>, &[R]) -> R,
+{
+    pub fn pre<U, P>(self, pre: P) -> WithPrePost<'a, T, U, R, P, F, S>
+    where
+        P: FnMut(&Node<T>, &U) -> U,
+    {
+        WithPrePost {
+            node: self.node,
+            pre,
+            post: self.post,
+            r: PhantomData,
+            u: PhantomData,
+            strategy: PhantomData,
+        }
+    }
+}
+
+/// Represents a combination of both pre and post traversals.
+pub struct WithPrePost<'a, T, R, U, F1, F2, S>
+where
+    F1: FnMut(&Node<T>, &R) -> R,
+    F2: FnMut(&Node<T>, &[U]) -> U,
+{
+    node: &'a Node<T>,
+    pre: F1,
+    post: F2,
+    r: PhantomData<R>,
+    u: PhantomData<U>,
+    strategy: PhantomData<S>,
 }

--- a/ntree/src/traversal/traverse/mod.rs
+++ b/ntree/src/traversal/traverse/mod.rs
@@ -75,7 +75,7 @@ where
 {
     pub fn post<U, P>(self, post: P) -> WithPrePost<'a, T, R, U, F, P, S>
     where
-        P: FnMut(&Node<T>, &[U]) -> U,
+        P: FnMut(&Node<T>, R, &[U]) -> U,
     {
         WithPrePost {
             node: self.node,
@@ -99,30 +99,11 @@ where
     strategy: PhantomData<S>,
 }
 
-impl<'a, T, R, F, S> WithPost<'a, T, R, F, S>
-where
-    F: FnMut(&Node<T>, &[R]) -> R,
-{
-    pub fn pre<U, P>(self, pre: P) -> WithPrePost<'a, T, U, R, P, F, S>
-    where
-        P: FnMut(&Node<T>, &U) -> U,
-    {
-        WithPrePost {
-            node: self.node,
-            pre,
-            post: self.post,
-            r: PhantomData,
-            u: PhantomData,
-            strategy: PhantomData,
-        }
-    }
-}
-
 /// Represents a combination of both pre and post traversals.
 pub struct WithPrePost<'a, T, R, U, F1, F2, S>
 where
     F1: FnMut(&Node<T>, &R) -> R,
-    F2: FnMut(&Node<T>, &[U]) -> U,
+    F2: FnMut(&Node<T>, R, &[U]) -> U,
 {
     node: &'a Node<T>,
     pre: F1,

--- a/ntree/src/traversal/traverse/mod.rs
+++ b/ntree/src/traversal/traverse/mod.rs
@@ -13,7 +13,7 @@ use std::marker::PhantomData;
 
 /// Implements the traverse algorithms for an immutable reference of a [`Node`].
 pub struct Traverse<'a, T, S> {
-    pub(crate) node: &'a Node<T>,
+    node: &'a Node<T>,
     strategy: PhantomData<S>,
 }
 
@@ -31,84 +31,120 @@ impl<'a, T, S> Traverse<'a, T, S> {
         self.node
     }
 
-    /// Returns the pre-order traversal entity for the tree.
-    pub fn pre<R, F>(self, pre: F) -> WithPre<'a, T, R, F, S>
-    where
-        F: FnMut(&Node<T>, &R) -> R,
-    {
-        WithPre {
+    /// Returns the `pre-order` traversal entity for the tree.
+    pub fn pre(self) -> InPre<'a, T, S> {
+        InPre {
             node: self.node,
-            pre,
-            r: PhantomData,
+            next: vec![self.node],
             strategy: PhantomData,
         }
     }
 
-    /// Returns the post-order traversal entity for the tree.
-    pub fn post<R, F>(self, post: F) -> WithPost<'a, T, R, F, S>
-    where
-        F: FnMut(&Node<T>, &[R]) -> R,
-    {
-        WithPost {
+    /// Returns the `post-order` traversal entity for the tree.
+    pub fn post(self) -> InPost<'a, T, S> {
+        InPost {
             node: self.node,
-            post,
-            r: PhantomData,
+            next: vec![(self.node, 0)],
             strategy: PhantomData,
         }
     }
 }
 
-/// Represents the pre-order traversal.
-pub struct WithPre<'a, T, R, F, S>
-where
-    F: FnMut(&Node<T>, &R) -> R,
-{
+/// Represents the `pre-order` traversal.
+pub struct InPre<'a, T, S> {
+    node: &'a Node<T>,
+    next: Vec<&'a Node<T>>,
+    strategy: PhantomData<S>,
+}
+
+impl<'a, T, S> Iterator for InPre<'a, T, S> {
+    type Item = &'a Node<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.next.pop()?;
+        self.next.extend(current.children.iter().rev());
+        Some(current)
+    }
+}
+
+impl<'a, T, S> InPre<'a, T, S> {
+    pub fn iter(self) -> impl Iterator<Item = &'a Node<T>> {
+        self
+    }
+}
+
+/// Represents the `post-order` traversal.
+pub struct InPost<'a, T, S> {
+    node: &'a Node<T>,
+    next: Vec<(&'a Node<T>, usize)>,
+    strategy: PhantomData<S>,
+}
+
+impl<'a, T, S> Iterator for InPost<'a, T, S> {
+    type Item = &'a Node<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (parent, next_child) = *self.next.last()?;
+        if let Some(next_child) = parent.children.get(next_child) {
+            self.next.last_mut()?.1 += 1;
+            self.next.push((next_child, 0));
+            return self.next();
+        }
+
+        self.next.pop().map(|(parent, _)| parent)
+    }
+}
+
+impl<'a, T, S> InPost<'a, T, S> {
+    pub fn iter(self) -> impl Iterator<Item = &'a Node<T>> {
+        self
+    }
+}
+
+/// Implements both traversals at once.
+pub struct PrePost<'a, T, R, F, S> {
     node: &'a Node<T>,
     pre: F,
     r: PhantomData<R>,
     strategy: PhantomData<S>,
 }
 
-impl<'a, T, R, F, S> WithPre<'a, T, R, F, S>
-where
-    F: FnMut(&Node<T>, &R) -> R,
-{
-    pub fn post<U, P>(self, post: P) -> WithPrePost<'a, T, R, U, F, P, S>
-    where
-        P: FnMut(&Node<T>, R, &[U]) -> U,
-    {
-        WithPrePost {
-            node: self.node,
-            pre: self.pre,
-            post,
-            r: PhantomData,
-            u: PhantomData,
-            strategy: PhantomData,
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node;
+
+    #[test]
+    fn test_pre_order_traversal() {
+        let root = node!(
+            10,
+            node!(20, node!(40), node!(50), node!(60)),
+            node!(30, node!(70), node!(80))
+        );
+
+        let mut result = Vec::new();
+        root.traverse()
+            .pre()
+            .iter()
+            .for_each(|n| result.push(n.value));
+
+        assert_eq!(result, vec![10, 20, 40, 50, 60, 30, 70, 80]);
     }
-}
 
-/// Represents the post-order traversal.
-pub struct WithPost<'a, T, R, F, S>
-where
-    F: FnMut(&Node<T>, &[R]) -> R,
-{
-    node: &'a Node<T>,
-    post: F,
-    r: PhantomData<R>,
-    strategy: PhantomData<S>,
-}
+    #[test]
+    fn test_post_order_traversal() {
+        let root = node!(
+            10,
+            node!(20, node!(40), node!(50), node!(60)),
+            node!(30, node!(70), node!(80))
+        );
 
-/// Represents a combination of both pre and post traversals.
-pub struct WithPrePost<'a, T, R, U, F1, F2, S>
-where
-    F1: FnMut(&Node<T>, &R) -> R,
-    F2: FnMut(&Node<T>, R, &[U]) -> U,
-{
-    node: &'a Node<T>,
-    pre: F1,
-    post: F2,
-    r: PhantomData<R>,
-    u: PhantomData<U>,
-    strategy: PhantomData<S>,
+        let mut result = Vec::new();
+        root.traverse()
+            .post()
+            .iter()
+            .for_each(|n| result.push(n.value));
+
+        assert_eq!(result, vec![40, 50, 60, 20, 70, 80, 30, 10]);
+    }
 }

--- a/ntree/src/traversal/traverse/sync.rs
+++ b/ntree/src/traversal/traverse/sync.rs
@@ -1,7 +1,7 @@
 //! Synchronous traversal implementation.
 
 use crate::{
-    traversal::{macros, Traverse, TraverseOwned},
+    traversal::{macros, Traverse},
     Asynchronous, InPost, InPre, Node, PrePost, Synchronous,
 };
 use std::marker::PhantomData;

--- a/ntree/src/traversal/traverse/sync.rs
+++ b/ntree/src/traversal/traverse/sync.rs
@@ -85,7 +85,7 @@ where
     F1: FnMut(&Node<T>, &R) -> R,
     F2: FnMut(&Node<T>, R, &[U]) -> U,
 {
-    /// Traverses the tree executing both associated closures.
+    /// Traverses the tree calling both associated closures when corresponding.
     pub fn traverse(mut self, base: R) -> Traverse<'a, T, Synchronous> {
         fn traverse_immersion<T, R, U, F1, F2>(
             root: &Node<T>,

--- a/ntree/src/traversal/traverse/sync.rs
+++ b/ntree/src/traversal/traverse/sync.rs
@@ -50,8 +50,7 @@ where
             let mut children: Vec<R> = root
                 .children
                 .iter()
-                .map(|node| traverse_immersion(node, &base, f))
-                .flatten()
+                .flat_map(|node| traverse_immersion(node, &base, f))
                 .collect();
 
             let mut preorder_list = vec![base];
@@ -77,8 +76,7 @@ where
             let mut children: Vec<R> = root
                 .children
                 .iter()
-                .map(|node| traverse_immersion(node, f))
-                .flatten()
+                .flat_map(|node| traverse_immersion(node, f))
                 .collect();
 
             children.push(f(root, &children));

--- a/ntree/src/traversal/traverse/sync.rs
+++ b/ntree/src/traversal/traverse/sync.rs
@@ -117,7 +117,7 @@ mod tests {
     }
 
     #[test]
-    fn test_traverse_pre() {
+    fn test_cascade_pre() {
         let root = node!(10, node!(20, node!(40)), node!(30, node!(50)));
 
         let mut result = Vec::new();
@@ -130,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn test_collapse_pre() {
+    fn test_map_pre() {
         let original = node!(1, node!(2, node!(5)), node!(3, node!(5)));
 
         let copy = original.clone();
@@ -146,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    fn test_traverse_post() {
+    fn test_reduce_post() {
         let root = node!(10, node!(20, node!(40)), node!(30, node!(50)));
 
         let mut result = Vec::new();
@@ -159,7 +159,7 @@ mod tests {
     }
 
     #[test]
-    fn test_collapse_post() {
+    fn test_map_post() {
         let original = node!(1, node!(2, node!(5)), node!(3, node!(5)));
 
         let copy = original.clone();
@@ -171,6 +171,41 @@ mod tests {
         assert_eq!(original, copy);
 
         let want = node!(true, node!(false, node!(false)), node!(true, node!(true)));
+        assert_eq!(new_root, want);
+    }
+
+    #[test]
+    fn test_reduce_pre_post() {
+        let root = node!(10, node!(20, node!(40)), node!(30, node!(50)));
+
+        let mut result = Vec::new();
+        root.traverse()
+            .post()
+            .with_pre(|current, base| current.value + base)
+            .reduce(0, |current, base, children| {
+                result.push(current.value + children.len() + base);
+                current.value + children.len() + base
+            });
+
+        assert_eq!(result, vec![110, 51, 140, 71, 22]);
+    }
+
+    #[test]
+    fn test_map_pre_post() {
+        let original = node!(1, node!(2, node!(5)), node!(3, node!(5)));
+
+        let copy = original.clone();
+        let new_root = copy
+            .traverse()
+            .post()
+            .with_pre(|current, base| current.value + base)
+            .map(0, |current, base, _| {
+                current.value % 2 != 0 && base % 2 == 0
+            });
+
+        assert_eq!(original, copy);
+
+        let want = node!(false, node!(false, node!(true)), node!(true, node!(false)));
         assert_eq!(new_root, want);
     }
 }

--- a/ntree/src/traversal/traverse_mut/async.rs
+++ b/ntree/src/traversal/traverse_mut/async.rs
@@ -1,6 +1,9 @@
 //! Asynchronous traversal implementation.
 
-use crate::{traversal::TraverseMut, Asynchronous, Node, Synchronous, TraverseOwned};
+use crate::{
+    traversal::{macros_async, TraverseMut},
+    Asynchronous, Node, Synchronous,
+};
 use async_recursion::async_recursion;
 use futures::future::join_all;
 use std::marker::PhantomData;
@@ -20,103 +23,10 @@ impl<'a, T: Sync + Send + 'a> TraverseMut<'a, T, Asynchronous> {
         }
     }
 
-    #[async_recursion]
-    async fn for_each_immersion<F>(root: &mut Node<T>, f: &F)
-    where
-        F: Fn(&mut Node<T>) + Sync + Send,
-    {
-        let futures: Vec<_> = root
-            .children
-            .iter_mut()
-            .map(|child| Self::for_each_immersion(child, f))
-            .collect();
-
-        join_all(futures).await;
-        f(root);
-    }
-
-    /// Traverses the tree rooted by self in `post-order`, calling the given closure along the way.
-    pub async fn for_each<F>(self, f: F) -> TraverseMut<'a, T, Asynchronous>
-    where
-        F: Fn(&mut Node<T>) + Sync + Send,
-    {
-        Self::for_each_immersion(self.node, &f).await;
-        self
-    }
-
-    #[async_recursion]
-    async fn map_immersion<F, R>(root: &mut Node<T>, f: &F) -> Node<R>
-    where
-        F: Fn(&mut Node<T>) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        Node::new(f(root)).with_children(
-            join_all(
-                root.children
-                    .iter_mut()
-                    .map(|child| Self::map_immersion(child, f)),
-            )
-            .await,
-        )
-    }
-
-    /// Traverses the tree rooted by self in `pre-order`, building a new tree by calling the given closure along the way.
-    pub async fn map<F, R>(self, f: F) -> TraverseOwned<R, Asynchronous>
-    where
-        F: Fn(&mut Node<T>) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        TraverseOwned::new_async(Self::map_immersion(self.node, &f).await)
-    }
-
-    #[async_recursion]
-    async fn reduce_immersion<F, R>(root: &mut Node<T>, f: &F) -> R
-    where
-        F: Fn(&mut Node<T>, Vec<R>) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        let results = join_all(
-            root.children
-                .iter_mut()
-                .map(|child| Self::reduce_immersion(child, f)),
-        )
-        .await;
-        f(root, results)
-    }
-
-    /// Traverses the tree rooted by self in `post-order`, calling the given closure along the way and providing its results from children to parent.
-    pub async fn reduce<F, R>(self, f: F) -> R
-    where
-        F: Fn(&mut Node<T>, Vec<R>) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        Self::reduce_immersion(self.node, &f).await
-    }
-
-    #[async_recursion]
-    async fn cascade_immersion<F, R>(root: &mut Node<T>, base: &R, f: &F)
-    where
-        F: Fn(&mut Node<T>, &R) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        let base = f(root, base);
-        join_all(
-            root.children
-                .iter_mut()
-                .map(|child| Self::cascade_immersion(child, &base, f)),
-        )
-        .await;
-    }
-
-    /// Traverses the tree rooted by self in `pre-order`, calling the given closure along the way and providing its result from parent to children.
-    pub async fn cascade<F, R>(self, base: R, f: F) -> TraverseMut<'a, T, Asynchronous>
-    where
-        F: Fn(&mut Node<T>, &R) -> R + Sync + Send,
-        R: Sized + Sync + Send,
-    {
-        Self::cascade_immersion(self.node, &base, &f).await;
-        self
-    }
+    macros_async::for_each!(&mut Node<T>, iter_mut);
+    macros_async::map!(&mut Node<T>, iter_mut);
+    macros_async::reduce!(&mut Node<T>, iter_mut);
+    macros_async::cascade!(&mut Node<T>, iter_mut);
 }
 
 #[cfg(test)]

--- a/ntree/src/traversal/traverse_mut/mod.rs
+++ b/ntree/src/traversal/traverse_mut/mod.rs
@@ -72,16 +72,16 @@ pub struct InPreMut<'a, T, S> {
     strategy: PhantomData<S>,
 }
 
-/// Implements the `pre-order` traversal.
-pub struct PreTravMut<'a, T, R, F, S> {
-    node: &'a mut Node<T>,
-    pre: F,
-    r: PhantomData<R>,
-    strategy: PhantomData<S>,
-}
-
 /// Represents the `post-order` traversal.
 pub struct InPostMut<'a, T, S> {
     node: &'a mut Node<T>,
+    strategy: PhantomData<S>,
+}
+
+/// Implements both traversals at once.
+pub struct PrePostMut<'a, T, R, F, S> {
+    node: &'a mut Node<T>,
+    pre: F,
+    r: PhantomData<R>,
     strategy: PhantomData<S>,
 }

--- a/ntree/src/traversal/traverse_mut/mod.rs
+++ b/ntree/src/traversal/traverse_mut/mod.rs
@@ -48,4 +48,40 @@ impl<'a, T, S> TraverseMut<'a, T, S> {
     pub fn node_mut(&mut self) -> &mut Node<T> {
         self.node
     }
+
+    /// Returns the `pre-order` traversal entity for the tree.
+    pub fn pre(self) -> InPreMut<'a, T, S> {
+        InPreMut {
+            node: self.node,
+            strategy: PhantomData,
+        }
+    }
+
+    /// Returns the `post-order` traversal entity for the tree.
+    pub fn post(self) -> InPostMut<'a, T, S> {
+        InPostMut {
+            node: self.node,
+            strategy: PhantomData,
+        }
+    }
+}
+
+/// Represents the `pre-order` traversal.
+pub struct InPreMut<'a, T, S> {
+    node: &'a mut Node<T>,
+    strategy: PhantomData<S>,
+}
+
+/// Implements the `pre-order` traversal.
+pub struct PreTravMut<'a, T, R, F, S> {
+    node: &'a mut Node<T>,
+    pre: F,
+    r: PhantomData<R>,
+    strategy: PhantomData<S>,
+}
+
+/// Represents the `post-order` traversal.
+pub struct InPostMut<'a, T, S> {
+    node: &'a mut Node<T>,
+    strategy: PhantomData<S>,
 }

--- a/ntree/src/traversal/traverse_mut/sync.rs
+++ b/ntree/src/traversal/traverse_mut/sync.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     traversal::{macros, TraverseMut},
-    Asynchronous, InPostMut, InPreMut, Node, PreTravMut, Synchronous, TraverseOwned,
+    Asynchronous, InPostMut, InPreMut, Node, PrePostMut, Synchronous,
 };
 use std::marker::PhantomData;
 
@@ -32,10 +32,15 @@ impl<'a, T> TraverseMut<'a, T, Synchronous> {
 impl<'a, T> InPreMut<'a, T, Synchronous> {
     macros::map_pre!(&mut Node<T>, iter_mut);
     macros::cascade!(&mut Node<T>, iter_mut);
+}
+
+impl<'a, T, S> InPostMut<'a, T, S> {
+    macros::reduce!(&mut Node<T>, iter_mut);
+    macros::map_post!(&mut Node<T>, iter_mut);
 
     /// Determines a closure to be executed in `pre-order` when traversing the tree.
-    pub fn with<R, F>(self, pre: F) -> PreTravMut<'a, T, R, F, Synchronous> {
-        PreTravMut {
+    pub fn with_pre<R, F>(self, pre: F) -> PrePostMut<'a, T, R, F, Synchronous> {
+        PrePostMut {
             node: self.node,
             pre,
             r: PhantomData,
@@ -44,17 +49,12 @@ impl<'a, T> InPreMut<'a, T, Synchronous> {
     }
 }
 
-impl<'a, T, R, F> PreTravMut<'a, T, R, F, Synchronous>
+impl<'a, T, R, F> PrePostMut<'a, T, R, F, Synchronous>
 where
     F: FnMut(&Node<T>, &R) -> R,
 {
     macros::reduce_pre_post!(&mut Node<T>, iter_mut);
     macros::map_pre_post!(&mut Node<T>, iter_mut);
-}
-
-impl<'a, T, S> InPostMut<'a, T, S> {
-    macros::reduce!(&mut Node<T>, iter_mut);
-    macros::map_post!(&mut Node<T>, iter_mut);
 }
 
 #[cfg(test)]

--- a/ntree/src/traversal/traverse_mut/sync.rs
+++ b/ntree/src/traversal/traverse_mut/sync.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     traversal::{macros, TraverseMut},
-    Asynchronous, Node, Synchronous, TraverseOwned,
+    Asynchronous, InPostMut, InPreMut, Node, PreTravMut, Synchronous, TraverseOwned,
 };
 use std::marker::PhantomData;
 
@@ -27,6 +27,34 @@ impl<'a, T> TraverseMut<'a, T, Synchronous> {
     macros::map!(&mut Node<T>, iter_mut);
     macros::reduce!(&mut Node<T>, iter_mut);
     macros::cascade!(&mut Node<T>, iter_mut);
+}
+
+impl<'a, T> InPreMut<'a, T, Synchronous> {
+    macros::map_pre!(&mut Node<T>, iter_mut);
+    macros::cascade!(&mut Node<T>, iter_mut);
+
+    /// Determines a closure to be executed in `pre-order` when traversing the tree.
+    pub fn with<R, F>(self, pre: F) -> PreTravMut<'a, T, R, F, Synchronous> {
+        PreTravMut {
+            node: self.node,
+            pre,
+            r: PhantomData,
+            strategy: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, R, F> PreTravMut<'a, T, R, F, Synchronous>
+where
+    F: FnMut(&Node<T>, &R) -> R,
+{
+    macros::reduce_pre_post!(&mut Node<T>, iter_mut);
+    macros::map_pre_post!(&mut Node<T>, iter_mut);
+}
+
+impl<'a, T, S> InPostMut<'a, T, S> {
+    macros::reduce!(&mut Node<T>, iter_mut);
+    macros::map_post!(&mut Node<T>, iter_mut);
 }
 
 #[cfg(test)]

--- a/ntree/src/traversal/traverse_owned/mod.rs
+++ b/ntree/src/traversal/traverse_owned/mod.rs
@@ -87,40 +87,6 @@ impl<T, S> Iterator for InPreOwned<T, S> {
     }
 }
 
-/// Implements the `pre-order` traversal.
-pub struct PreTravOwned<T, R, F, S> {
-    node: Node<T>,
-    pre: F,
-    r: PhantomData<R>,
-    strategy: PhantomData<S>,
-}
-
-impl<T, R, F, S> PreTravOwned<T, R, F, S> {
-    /// Determines a closure to be executed in `post-order` when traversing the tree.
-    pub fn post<U, P>(self, post: P) -> PrePostTravOwned<T, R, U, F, P, S> {
-        PrePostTravOwned {
-            node: self.node,
-            pre: self.pre,
-            post,
-            r: PhantomData,
-            u: PhantomData,
-            strategy: PhantomData,
-        }
-    }
-
-    /// Determines a closure to be executed in `post-order` when traversing the tree.
-    pub fn post_map<U, P>(self, post: P) -> PrePostMapOwned<T, R, U, F, P, S> {
-        PrePostMapOwned {
-            node: self.node,
-            pre: self.pre,
-            post,
-            r: PhantomData,
-            u: PhantomData,
-            strategy: PhantomData,
-        }
-    }
-}
-
 /// Represents the `post-order` traversal.
 pub struct InPostOwned<T, S> {
     next: Vec<Node<T>>,
@@ -149,23 +115,11 @@ impl<T, S> Iterator for InPostOwned<T, S> {
     }
 }
 
-/// Represents a combination of both pre and post traversals.
-pub struct PrePostTravOwned<T, R, U, F1, F2, S> {
+/// Implements both traversals at once.
+pub struct PrePostOwned<T, R, F, S> {
     node: Node<T>,
-    pre: F1,
-    post: F2,
+    pre: F,
     r: PhantomData<R>,
-    u: PhantomData<U>,
-    strategy: PhantomData<S>,
-}
-
-/// Represents a combination of both pre and post map contructors.
-pub struct PrePostMapOwned<T, R, U, F1, F2, S> {
-    node: Node<T>,
-    pre: F1,
-    post: F2,
-    r: PhantomData<R>,
-    u: PhantomData<U>,
     strategy: PhantomData<S>,
 }
 


### PR DESCRIPTION
Add `WithPre`, `WithPost` and `WithPrePost` entities to perform regular traversals.